### PR TITLE
fix: replace uptime with real NTP time in Telegram alerts

### DIFF
--- a/src/core/infrastructure/ntp_service.cpp
+++ b/src/core/infrastructure/ntp_service.cpp
@@ -1,0 +1,139 @@
+#include "ntp_service.h"
+#include <WiFi.h>
+
+// Static member definitions
+WiFiUDP* NTPService::ntpUDP = nullptr;
+NTPClient* NTPService::timeClient = nullptr;
+bool NTPService::initialized = false;
+unsigned long NTPService::lastSync = 0;
+
+bool NTPService::initialize() {
+  if (initialized) return true;
+  
+  Serial.println("[NTP] Initializing NTP service...");
+  
+  // Check WiFi connection
+  if (WiFi.status() != WL_CONNECTED) {
+    Serial.println("[NTP] ERROR: WiFi not connected!");
+    return false;
+  }
+  
+  // Setup NTP client
+  setupNTPClient();
+  
+  // Initial time sync
+  if (syncTime()) {
+    initialized = true;
+    lastSync = millis();
+    Serial.println("[NTP] Service initialized successfully!");
+    return true;
+  } else {
+    Serial.println("[NTP] ERROR: Failed to sync time!");
+    return false;
+  }
+}
+
+void NTPService::cleanup() {
+  if (timeClient) {
+    delete timeClient;
+    timeClient = nullptr;
+  }
+  
+  if (ntpUDP) {
+    delete ntpUDP;
+    ntpUDP = nullptr;
+  }
+  
+  initialized = false;
+  lastSync = 0;
+}
+
+bool NTPService::syncTime() {
+  if (!initialized || !timeClient) {
+    return false;
+  }
+  
+  Serial.println("[NTP] Syncing time...");
+  
+  if (timeClient->update()) {
+    lastSync = millis();
+    Serial.printf("[NTP] Time synced: %s\n", getFormattedTime().c_str());
+    return true;
+  } else {
+    Serial.println("[NTP] ERROR: Time sync failed!");
+    return false;
+  }
+}
+
+String NTPService::getCurrentTime() {
+  if (!initialized || !timeClient) {
+    // Fallback to uptime if NTP not available
+    unsigned long now = millis();
+    unsigned long hours = (now / 3600000) % 24;
+    unsigned long minutes = (now / 60000) % 60;
+    unsigned long seconds = (now / 1000) % 60;
+    
+    String timeStr = "";
+    if (hours < 10) timeStr += "0";
+    timeStr += String(hours) + ":";
+    if (minutes < 10) timeStr += "0";
+    timeStr += String(minutes) + ":";
+    if (seconds < 10) timeStr += "0";
+    timeStr += String(seconds);
+    
+    return timeStr + " (uptime)";
+  }
+  
+  // Check if we need to sync
+  if (millis() - lastSync > SYNC_INTERVAL_MS) {
+    syncTime();
+  }
+  
+  unsigned long epochTime = timeClient->getEpochTime();
+  return formatTime(epochTime);
+}
+
+String NTPService::getFormattedTime() {
+  if (!initialized || !timeClient) {
+    return "NTP not available";
+  }
+  
+  unsigned long epochTime = timeClient->getEpochTime();
+  return formatTime(epochTime);
+}
+
+bool NTPService::isTimeSynced() {
+  return initialized && timeClient && timeClient->isTimeSet();
+}
+
+void NTPService::setupNTPClient() {
+  // Get configuration
+  String ntpServer = ConfigLoader::getNtpServer();
+  int timezoneOffset = ConfigLoader::getTimezoneOffset();
+  
+  // Create UDP and NTP client
+  ntpUDP = new WiFiUDP();
+  timeClient = new NTPClient(*ntpUDP, ntpServer.c_str(), timezoneOffset, 60000);
+  
+  Serial.printf("[NTP] Configured: Server=%s, Offset=%d seconds\n", 
+               ntpServer.c_str(), timezoneOffset);
+}
+
+String NTPService::formatTime(unsigned long epochTime) {
+  // Convert epoch time to local time components
+  unsigned long localTime = epochTime;
+  
+  unsigned long hours = (localTime % 86400) / 3600;
+  unsigned long minutes = (localTime % 3600) / 60;
+  unsigned long seconds = localTime % 60;
+  
+  String timeStr = "";
+  if (hours < 10) timeStr += "0";
+  timeStr += String(hours) + ":";
+  if (minutes < 10) timeStr += "0";
+  timeStr += String(minutes) + ":";
+  if (seconds < 10) timeStr += "0";
+  timeStr += String(seconds);
+  
+  return timeStr;
+}

--- a/src/core/infrastructure/ntp_service.h
+++ b/src/core/infrastructure/ntp_service.h
@@ -1,0 +1,33 @@
+#pragma once
+#include <Arduino.h>
+#include <WiFiUdp.h>
+#include <NTPClient.h>
+#include "config/config_loader.h"
+
+class NTPService {
+private:
+  static WiFiUDP* ntpUDP;
+  static NTPClient* timeClient;
+  static bool initialized;
+  static unsigned long lastSync;
+  static const unsigned long SYNC_INTERVAL_MS = 3600000; // 1 hour
+  
+public:
+  // Initialization
+  static bool initialize();
+  static void cleanup();
+  
+  // Time management
+  static bool syncTime();
+  static String getCurrentTime();
+  static String getFormattedTime();
+  static bool isTimeSynced();
+  
+  // Status
+  static bool isInitialized() { return initialized; }
+  
+private:
+  // Internal methods
+  static void setupNTPClient();
+  static String formatTime(unsigned long epochTime);
+};

--- a/src/core/infrastructure/telegram_service.cpp
+++ b/src/core/infrastructure/telegram_service.cpp
@@ -221,20 +221,8 @@ String TelegramService::formatTime(unsigned long seconds) const {
 }
 
 String TelegramService::getCurrentTime() const {
-  unsigned long now = millis();
-  unsigned long hours = (now / 3600000) % 24;
-  unsigned long minutes = (now / 60000) % 60;
-  unsigned long seconds = (now / 1000) % 60;
-  
-  String timeStr = "";
-  if (hours < 10) timeStr += "0";
-  timeStr += String(hours) + ":";
-  if (minutes < 10) timeStr += "0";
-  timeStr += String(minutes) + ":";
-  if (seconds < 10) timeStr += "0";
-  timeStr += String(seconds);
-  
-  return timeStr;
+  // Use NTP service for real time instead of uptime
+  return NTPService::getCurrentTime();
 }
 
 bool TelegramService::sendMessage(const String& message) {

--- a/src/core/infrastructure/telegram_service.h
+++ b/src/core/infrastructure/telegram_service.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "core/domain/alert.h"
 #include "ssl_mutex_manager.h"
+#include "ntp_service.h"
 #include <Arduino.h>
 
 class TelegramService {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,7 @@
 #include "core/infrastructure/telegram_service.h"
 #include "core/infrastructure/ssl_mutex_manager.h"
 #include "core/infrastructure/memory_manager.h"
+#include "core/infrastructure/ntp_service.h"
 #include "ui/display_manager.h"
 #include "ui/touch_handler.h"
 #include "ui/led_controller.h"
@@ -122,6 +123,17 @@ void setup() {
   String password = ConfigLoader::getWifiPassword();
   if (!wifiService->initialize(ssid, password)) {
     Serial.println("[MAIN] WARNING: WiFi initialization failed, will retry...");
+  }
+  
+  // Initialize NTP service (after WiFi)
+  if (WiFi.status() == WL_CONNECTED) {
+    if (NTPService::initialize()) {
+      Serial.println("[MAIN] NTP service initialized!");
+    } else {
+      Serial.println("[MAIN] WARNING: NTP service failed to initialize!");
+    }
+  } else {
+    Serial.println("[MAIN] WARNING: WiFi not connected, skipping NTP initialization");
   }
   
   // Initialize Telegram


### PR DESCRIPTION
- Create NTPService for real time synchronization using NTPClient
- Update TelegramService to use NTP time instead of millis() uptime
- Add NTP initialization in main.cpp after WiFi connection
- Configure timezone offset and NTP server from config.env
- Fallback to uptime if NTP is not available (with indicator)
- Fix 'Detected' field in alerts to show actual time instead of system uptime

Resolves issue where alert timestamps showed system uptime instead of real time.