### PR TITLE
feat: implement Telegram reply thread system

### DIFF
--- a/src/core/infrastructure/telegram_service/telegram_service.h
+++ b/src/core/infrastructure/telegram_service/telegram_service.h
@@ -12,6 +12,10 @@ private:
   bool sendingMessage;
   Alert* alerts[6]; // Array of alert objects
   
+  // Reply thread management
+  uint32_t lastMessageIds[6]; // message_id por target para reply
+  bool isThreadActive[6];     // thread ativa por target
+  
   // Configuration
   static const uint8_t MAX_FAILURES_BEFORE_ALERT = 3;
   static const unsigned long ALERT_COOLDOWN_MS = 300000; // 5 minutes
@@ -49,7 +53,7 @@ private:
   String getCurrentTime() const;
   
   // HTTP communication
-  bool sendMessage(const String& message);
+  bool sendMessage(const String& message, int targetIndex = -1, bool isRecovery = false);
   
   // Alert logic
   bool isTimeForAlert(int targetIndex, bool isRecovery = false) const;


### PR DESCRIPTION
- Add thread management variables (lastMessageIds, isThreadActive)
- Modify sendMessage to support reply_to_message_id
- Implement reply logic for down alerts (continues thread)
- Implement reply logic for recovery alerts (ends thread)
- Each service gets its own conversation thread
- Down alerts chain together until recovery
- Recovery ends the thread cycle
- Compiles successfully with no errors