### PR TITLE
🔧 Fix critical timestamp comparison logic in SD sync

### DIFF
--- a/src/core/infrastructure/sdcard_manager/sdcard_manager.h
+++ b/src/core/infrastructure/sdcard_manager/sdcard_manager.h
@@ -39,7 +39,8 @@ public:
   uint32_t calculateFileHash(File& file);
   
   // New: Compare using timestamps (most reliable when available)
-  bool compareByTimestamp();
+  // Returns: 1 = SD newer, 0 = same/older, -1 = cannot determine
+  int compareByTimestamp();
   
   // New: Check if force sync is enabled
   bool isForceSyncEnabled();


### PR DESCRIPTION
✅ Critical Bug Fix:
- Fix compareByTimestamp() return type confusion
- Change from bool to int with clear semantics:
  - 1 = SD newer
  - 0 = SD same/older
  - -1 = cannot determine
- Eliminate ambiguity between 'SD older' and 'cannot determine'

🎯 Impact:
- Prevents unnecessary sync operations when SD is definitively older
- Improves timestamp comparison accuracy when NTP is available
- Fixes logic that was treating 'SD older' as 'indeterminate'

This resolves the issue where definitive timestamp results indicating SD config is not newer were being ignored, causing fallback to less reliable hash/size comparisons.